### PR TITLE
Fix compatibility with other library that make use of gesture as well

### DIFF
--- a/src/RefreshControl.web.js
+++ b/src/RefreshControl.web.js
@@ -75,7 +75,7 @@ export default function RefreshControl({
     PanResponder.create({
       onStartShouldSetPanResponder: () => false,
       onStartShouldSetPanResponderCapture: () => false,
-      onMoveShouldSetPanResponder: () => {
+      onMoveShouldSetPanResponder: (_,gestureState) => {
         if (!containerRef.current) return false
         const containerDOM = findNodeHandle(containerRef.current)
         if (!containerDOM) return false

--- a/src/RefreshControl.web.js
+++ b/src/RefreshControl.web.js
@@ -80,6 +80,7 @@ export default function RefreshControl({
         const containerDOM = findNodeHandle(containerRef.current)
         if (!containerDOM) return false
         return containerDOM.children[0].scrollTop === 0
+        && (Math.abs(gestureState.dy) > Math.abs(gestureState.dx) * 2 && Math.abs(gestureState.vy) > Math.abs(gestureState.vx) * 2.5)
       },
       onMoveShouldSetPanResponderCapture: () => false,
       onPanResponderMove: (_, gestureState) => {


### PR DESCRIPTION
The gesture detection in this package is too lax so it causes issue when using this with some other packages that uses gesture detection: for example List.Swipeable from react-native-elements.

I changed the detection rule so that refresh will be triggered only when user gesture is pulling down vertically with certain velocity.