### PR TITLE
fix: Only set CustomRefreshControl if the user sets onRefresh prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,17 +16,23 @@ export function patchFlatListProps(options = {}) {
 function setCustomFlatListWeb(options) {
   FlatList.defaultProps = {
     ...FlatList.defaultProps,
-    //eslint-disable-next-line react/display-name
-    renderScrollComponent: props => (
+    // eslint-disable-next-line react/display-name
+    renderScrollComponent: (props) => (
       <ScrollView
         {...props}
-        //eslint-disable-next-line react/prop-types
+        // eslint-disable-next-line react/prop-types
         refreshControl={
-          props.onRefresh 
+          props.onRefresh
             ? (
-            <CustomRefreshControl {...options} refreshing={props.refreshing} onRefresh={props.onRefresh} />)
-            : props.refreshControl} // fallback to existing refreshControl if any
+              <CustomRefreshControl
+                {...options}
+                refreshing={props.refreshing}
+                onRefresh={props.onRefresh}
+              />
+            )
+            : props.refreshControl // fallback to existing refreshControl if any
+        }
       />
     ),
-  }
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,11 @@ function setCustomFlatListWeb(options) {
       <ScrollView
         {...props}
         //eslint-disable-next-line react/prop-types
-        refreshControl={<CustomRefreshControl {...options} refreshing={props.refreshing} onRefresh={props.onRefresh} />}
+        refreshControl={
+          props.onRefresh 
+            ? (
+            <CustomRefreshControl {...options} refreshing={props.refreshing} onRefresh={props.onRefresh} />)
+            : props.refreshControl} // fallback to existing refreshControl if any
       />
     ),
   }


### PR DESCRIPTION
Hi! 👋 
      
Thanks for making this component available!

I ran into the issue described here: https://github.com/NiciusB/react-native-web-refresh-control/issues/12 So I decided to attempt the solution proposed there:

Solution: Only set CustomRefreshControl if the user sets onRefresh prop

This solves my problem. How was this tested:

1. I tested this on web version of my app
2. Ensured other FlatLists dont break